### PR TITLE
Begin adding auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository contains my notes for how to quickly provision a local environme
 1. `kind create cluster`
 2. Ensure you're using the kind cluster context with kubectl: `kubectl config set current-context kind-kind`
 3. Verify the cluster is working: `kubectl get nodes`
-4. Install OpenFaaS to the local kind cluster: `helmfile apply`
+4. Install OpenFaaS to the local kind cluster: `KEYCLOAK_PASSWORD=foo helmfile apply`
 5. Show the state of the installed chart: `helm list -n openfaas`
 6. Wait for OpenFaaS pods to become ready: `kubectl get po -n openfaas --watch`
 7. Add `127.0.0.1 gateway.openfaas.local` to `/etc/hosts` to map the [default host entry](https://github.com/openfaas/faas-netes/blob/master/chart/openfaas/values.yaml#L118) for OpenFaaS ingress
@@ -37,6 +37,10 @@ When you're done, you can wipe the slate clean by running:
 
 * `kind delete cluster`
 
+## Troubleshooting Notes
+
+* Watch envoy logs: `kubectl logs -n envoy -f $(kubectl get po -n envoy -o=jsonpath='{.items[].metadata.name}')`
+
 ## TODO
 
 * [ ] Investigate using knative build with OpenFaaS
@@ -50,6 +54,10 @@ When you're done, you can wipe the slate clean by running:
   * https://kind.sigs.k8s.io/docs/user/private-registries/
 * [ ] Create a node 12 hapi-based template, possibly submit it to OpenFaaS
 * [ ] Add OIDC-based authentication
+  * The OpenFaaS Gateway supports OIDC, but [requires a commercial license](https://docs.openfaas.com/reference/authentication/#oauth2-support-in-the-api-gateway-commercial-add-on). It should be possible to work around this with a combination of Keycloak and Envoy.
+  * Using Keycloak has the added advantage of having your IdP manage user and service credentials from one location.
+* [ ] Add CoreDNS for a local DNS provider for services
+* [ ] Include an example function that [leverages a secret](https://docs.openfaas.com/reference/secrets/#use-the-secret-in-your-function)
 
 ## References
 

--- a/envoy/.helmignore
+++ b/envoy/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/envoy/Chart.yaml
+++ b/envoy/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: envoy
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: v1.11.0

--- a/envoy/files/envoy-config.yaml
+++ b/envoy/files/envoy-config.yaml
@@ -88,5 +88,4 @@ static_resources:
         - socket_address:
             address: {{ .host }}
             port_value: {{ .port }}  # needs to be the port that keycloak is listening on
-      tls_context: { sni: {{ .host }} }
   {{- end }}

--- a/envoy/files/envoy-config.yaml
+++ b/envoy/files/envoy-config.yaml
@@ -1,0 +1,92 @@
+static_resources:
+  listeners:
+    - address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: {{ .Values.envoy.port }}
+      filter_chains:
+        - filters:
+            - name: envoy.http_connection_manager
+              config:
+                codec_type: auto
+                stat_prefix: ingress_http
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: backend
+                      domains:
+                        - "*"
+                      routes:
+                        - match:
+                            prefix: "/" # need to update this to forward to the functions, async-functions, system, etc paths of openfaas
+                          route:
+                            cluster: {{ include "envoy.fullname" . }}
+                            timeout: 60s
+                http_filters:
+                  - name: envoy.filters.http.jwt_authn
+                    config:
+                      providers:
+                      {{- range .Values.envoy.providers }}
+                        {{ .name }}:
+                          audiences:
+                        {{- range .audiences }}
+                            - {{ . }}
+                        {{- end }}
+                          issuer: "http://{{ .host }}:{{ .port }}/auth/realms/{{ .realm }}"
+                          remote_jwks:
+                            http_uri:
+                              uri: "http://{{ .host }}:{{ .port }}/auth/realms/{{ .realm }}/protocol/openid-connect/certs"
+                              cluster: {{ .name }}
+                          forward: true
+                      {{- end }}
+                      rules:
+                        - match:
+                            prefix: /
+                          requires:
+                            {{- if eq (len .Values.envoy.providers) 1 }}
+                              {{- range .Values.envoy.providers }}
+                              provider_name: {{ .name }}
+                              {{- end }}
+                            {{- else }}
+                              requires_any:
+                                requirements:
+                                {{- range .Values.envoy.providers }}
+                                - provider_name: {{ .name }}
+                                {{- end }}
+                            {{- end }}
+                  - name: envoy.router
+                    config: {}
+                access_log:
+                  name: envoy.file_access_log
+                  config:
+                    path: /dev/stdout
+                    json_format:
+                      time: "%START_TIME%"
+                      xff: "%REQ(X-FORWARDED-FOR)%"
+                      src: "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"
+                      protocol: "%PROTOCOL%"
+                      method: "%REQ(:METHOD)%"
+                      path: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"
+                      response: "%RESPONSE_CODE%"
+                      duration: "%DURATION%"
+                      ua: "%REQ(USER-AGENT)%"
+                      id: "%REQ(X-REQUEST-ID)%"
+  clusters:
+    - name: {{ include "envoy.fullname" . }}
+      connect_timeout: 0.25s
+      type: strict_dns
+      lb_policy: ROUND_ROBIN
+      hosts:
+        - socket_address:
+            address: {{ .Values.openfaas.gateway.host }} # needs to be the service name of the openfaas gateway
+            port_value: {{ .Values.openfaas.gateway.port }}
+  {{- range .Values.envoy.providers }}
+    - name: {{ .name }}
+      connect_timeout: 1s
+      type: strict_dns
+      hosts:
+        - socket_address:
+            address: {{ .host }}
+            port_value: {{ .port }}  # needs to be the port that keycloak is listening on
+      tls_context: { sni: {{ .host }} }
+  {{- end }}

--- a/envoy/templates/NOTES.txt
+++ b/envoy/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "envoy.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "envoy.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "envoy.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "envoy.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+{{- end }}

--- a/envoy/templates/_helpers.tpl
+++ b/envoy/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "envoy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "envoy.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "envoy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "envoy.labels" -}}
+helm.sh/chart: {{ include "envoy.chart" . }}
+{{ include "envoy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "envoy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "envoy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "envoy.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "envoy.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/envoy/templates/deployment.yaml
+++ b/envoy/templates/deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "envoy.fullname" . }}
+  labels:
+    {{- include "envoy.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "envoy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "envoy.selectorLabels" . | nindent 8 }}
+      annotations:
+        checksum/envoy-config: {{ include (print $.Template.BasePath "/envoy-configmap.yaml") . | sha256sum }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "envoy.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.envoy.port }}
+              protocol: TCP
+          command:
+            - envoy
+            - -c
+            - /etc/envoy-config/config.yaml
+          volumeMounts:
+            - name: envoy-config
+              mountPath: /etc/envoy-config
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.envoy.port }}
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+            successThreshold: 1
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.envoy.port }}
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+            successThreshold: 1
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: envoy-config
+          configMap:
+            name: {{ include "envoy.fullname" . }}-config
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/envoy/templates/deployment.yaml
+++ b/envoy/templates/deployment.yaml
@@ -16,6 +16,10 @@ spec:
       annotations:
         checksum/envoy-config: {{ include (print $.Template.BasePath "/envoy-configmap.yaml") . | sha256sum }}
     spec:
+      hostAliases:
+        - ip: "{{ .Values.envoy.keycloakHostIp }}"
+          hostnames:
+            - keycloak.openfaas.local
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -37,6 +41,8 @@ spec:
             - envoy
             - -c
             - /etc/envoy-config/config.yaml
+            - --log-level
+            - debug
           volumeMounts:
             - name: envoy-config
               mountPath: /etc/envoy-config

--- a/envoy/templates/envoy-configmap.yaml
+++ b/envoy/templates/envoy-configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "envoy.fullname" . }}-config
+  labels:
+    {{- include "envoy.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    {{- tpl (.Files.Get "files/envoy-config.yaml") . | nindent 4 }}

--- a/envoy/templates/ingress.yaml
+++ b/envoy/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "envoy.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "envoy.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/envoy/templates/service.yaml
+++ b/envoy/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "envoy.fullname" . }}
+  labels:
+    {{- include "envoy.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.envoy.port }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "envoy.selectorLabels" . | nindent 4 }}

--- a/envoy/templates/serviceaccount.yaml
+++ b/envoy/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "envoy.serviceAccountName" . }}
+  labels:
+{{ include "envoy.labels" . | nindent 4 }}
+{{- end -}}

--- a/envoy/templates/tests/test-connection.yaml
+++ b/envoy/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "envoy.fullname" . }}-test-connection"
+  labels:
+{{ include "envoy.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args:  ['{{ include "envoy.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/envoy/values.yaml
+++ b/envoy/values.yaml
@@ -14,19 +14,14 @@ fullnameOverride: ""
 
 envoy:
   port: 8080
+  keycloakHostIp: "127.0.0.1"
   providers:
     - name: keycloak-external
       host: keycloak.openfaas.local
       port: 30080
       realm: local
       audiences:
-        - local-client
-    - name: keycloak-internal
-      host: keycloak-http.keycloak
-      port: 80
-      realm: local
-      audiences:
-        - local-client
+        - account
 
 openfaas:
   gateway:

--- a/envoy/values.yaml
+++ b/envoy/values.yaml
@@ -1,0 +1,83 @@
+# Default values for envoy.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: envoyproxy/envoy-alpine
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+envoy:
+  port: 8080
+  providers:
+    - name: keycloak-external
+      host: keycloak.openfaas.local
+      port: 30080
+      realm: local
+      audiences:
+        - local-client
+    - name: keycloak-internal
+      host: keycloak-http.keycloak
+      port: 80
+      realm: local
+      audiences:
+        - local-client
+
+openfaas:
+  gateway:
+    host: gateway.openfaas
+    port: 8080
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 8080
+
+ingress:
+  enabled: true
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  hosts:
+    - host: gateway.openfaas.local
+      paths:
+        - /
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -1,60 +1,109 @@
 repositories:
-- name: stable
-  url: https://kubernetes-charts.storage.googleapis.com/
-- name: incubator
-  url: https://kubernetes-charts-incubator.storage.googleapis.com/
-- name: openfaas
-  url: https://openfaas.github.io/faas-netes
+  - name: stable
+    url: https://kubernetes-charts.storage.googleapis.com/
+  - name: incubator
+    url: https://kubernetes-charts-incubator.storage.googleapis.com/
+  - name: openfaas
+    url: https://openfaas.github.io/faas-netes
+  - name: codecentric
+    url: https://codecentric.github.io/helm-charts
 releases:
-- name: namespaces
-  chart: incubator/raw
-  values:
-  - resources:
-    - apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: openfaas
-        labels:
-          role: openfaas-system
-          access: openfaas-system
-      spec: {}
-    - apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: openfaas-fn
-        labels:
-          role: openfaas-fn
-      spec: {}
-    - apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: nginx
-      spec: {}
-- name: nginx-ingress
-  namespace: nginx
-  chart: stable/nginx-ingress
-  set:
-    - name: controller.kind
-      value: DaemonSet
-    - name: controller.service.type
-      value: NodePort
-    - name: controller.service.nodePorts.http
-      value: 30080
-    - name: controller.service.nodePorts.https
-      value: 30443
-- name: openfaas
-  namespace: openfaas
-  chart: openfaas/openfaas
-  set:
-  - name: basic_auth
-    value: false
-  - name: functionNamespace
-    value: openfaas-fn
-  - name: operator.create
-    value: true
-  - name: operator.createCRD
-    value: true
-  - name: faasnetes.imagePullPolicy
-    value: Never
-  - name: ingress.enabled
-    value: true
+  - name: namespaces
+    chart: incubator/raw
+    values:
+      - resources:
+          - apiVersion: v1
+            kind: Namespace
+            metadata:
+              name: openfaas
+              labels:
+                role: openfaas-system
+                access: openfaas-system
+            spec: {}
+          - apiVersion: v1
+            kind: Namespace
+            metadata:
+              name: openfaas-fn
+              labels:
+                role: openfaas-fn
+            spec: {}
+          - apiVersion: v1
+            kind: Namespace
+            metadata:
+              name: nginx
+            spec: {}
+          - apiVersion: v1
+            kind: Namespace
+            metadata:
+              name: keycloak
+            spec: {}
+          - apiVersion: v1
+            kind: Namespace
+            metadata:
+              name: envoy
+            spec: {}
+          - apiVersion: v1
+            kind: Secret
+            type: Opaque
+            metadata:
+              name: keycloak-admin-passwd
+              namespace: keycloak
+            data:
+              password: {{ requiredEnv "KEYCLOAK_PASSWORD" | trim | b64enc }}
+  - name: nginx-ingress
+    namespace: nginx
+    chart: stable/nginx-ingress
+    needs:
+      - namespaces
+    set:
+      - name: controller.kind
+        value: DaemonSet
+      - name: controller.service.type
+        value: NodePort
+      - name: controller.service.nodePorts.http
+        value: 30080
+      - name: controller.service.nodePorts.https
+        value: 30443
+  - name: openfaas
+    namespace: openfaas
+    chart: openfaas/openfaas
+    needs:
+      - namespaces
+    set:
+      - name: basic_auth
+        value: false
+      - name: functionNamespace
+        value: openfaas-fn
+      - name: exposeServices
+        value: false
+      - name: serviceType
+        value: ClusterIP
+      - name: operator.create
+        value: true
+      - name: operator.createCRD
+        value: true
+      - name: faasnetes.imagePullPolicy
+        value: Never
+      - name: ingress.enabled
+        value: false
+  - name: keycloak
+    namespace: keycloak
+    chart: codecentric/keycloak
+    set:
+      - name: keycloak.ingress.enabled
+        value: true
+      - name: keycloak.ingress.hosts
+        values:
+          - keycloak.openfaas.local
+      - name: keycloak.username
+        value: admin
+      - name: keycloak.existingSecret
+        value: keycloak-admin-passwd
+  - name: envoy
+    namespace: envoy
+    chart: ./envoy
+    needs:
+      - namespaces
+    values:
+      - "./envoy/values.yaml"
+    wait: true

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -106,4 +106,7 @@ releases:
       - namespaces
     values:
       - "./envoy/values.yaml"
+    set:
+      - name: envoy.keycloakHostIp
+        value: "{{ requiredEnv "KEYCLOAK_IP" | trim }}"
     wait: true


### PR DESCRIPTION
TODO:

* [ ] - Update docs on how to access the locally running keycloak
* [ ] - Import a pre-defined realm with a pre-defined client
  * can use the `KEYCLOAK_IMPORT` environment variable to reference a path to a mounted realm.json
* [ ] - Add an example of how to acquire an access token from the token endpoint using the client_id and secret
*  [x] - Investigate if the Authorization Code Flow should be used to protect the OpenFaaS Gateway UI